### PR TITLE
Add Godot card beat prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# codex_godot_game_card_music
+# Card Beat Prototype
+
+A minimal Godot 4.2 prototype combining card interactions with beat-reactive visuals and simple synth audio.
+
+## Features
+- Clickable UI cards that play procedural sine wave tones.
+- Particle effects triggered when cards are used.
+- Timer-based beat events that drive simple scale animations.
+- Placeholder procedural audio generation using `AudioStreamGenerator`.
+
+## Running on macOS with Godot 4.2
+1. Install [Godot 4.2](https://godotengine.org/download) for macOS.
+2. Clone or download this repository:
+   ```bash
+   git clone https://example.com/codex_godot_game_card_music.git
+   ```
+3. Open Godot, choose **Import/Scan** and select the project folder.
+4. Run the project (press **F5**) to see the prototype in action.
+
+This project is an MVP intended for experimentation and can be expanded into a full card-based rogue-like rhythm game.
+

--- a/project.godot
+++ b/project.godot
@@ -1,0 +1,8 @@
+[gd_resource type="ProjectSettings" load_steps=2 format=5]
+
+[resource]
+config/name="CardBeatPrototype"
+config/version="0.1"
+run/main_scene="res://scenes/main.tscn"
+application/run/low_processor_mode=true
+

--- a/scenes/card.gd
+++ b/scenes/card.gd
@@ -1,0 +1,36 @@
+extends Button
+
+# Frequency of the synth tone in Hertz
+@export var frequency: float = 440.0
+
+# Cached references to child nodes for particles and audio
+@onready var particles: GPUParticles2D = $Particles
+@onready var audio_player: AudioStreamPlayer = $AudioStreamPlayer
+var playback: AudioStreamGeneratorPlayback
+
+func _ready() -> void:
+    # Prepare an audio generator for simple sine wave tones
+    var generator := AudioStreamGenerator.new()
+    generator.mix_rate = 44100
+    generator.buffer_length = 0.2
+    audio_player.stream = generator
+    audio_player.play()
+    playback = audio_player.get_stream_playback() as AudioStreamGeneratorPlayback
+
+func _pressed() -> void:
+    # Called when the card (button) is clicked
+    play_tone(frequency)
+    particles.restart() # Trigger particle burst
+
+func play_tone(freq: float, length: float = 0.2) -> void:
+    # Generates a short sine wave and feeds it to the audio playback
+    var frames := int(44100 * length)
+    var data := PackedVector2Array()
+    var phase := 0.0
+    var increment := TAU * freq / 44100.0
+    for i in frames:
+        var sample := sin(phase)
+        phase += increment
+        data.append(Vector2(sample, sample))
+    playback.push_buffer(data)
+

--- a/scenes/card.tscn
+++ b/scenes/card.tscn
@@ -1,0 +1,23 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource path="res://scenes/card.gd" type="Script" id=1]
+
+[sub_resource type="ParticleProcessMaterial" id=1]
+# Basic particle material; defaults create small burst
+
+[node name="Card" type="Button"]
+custom_minimum_size = Vector2(120, 180)
+text = "Card"
+script = ExtResource(1)
+
+[node name="Particles" type="GPUParticles2D" parent="."]
+emitting = false
+one_shot = true
+amount = 30
+lifetime = 0.5
+process_material = SubResource(1)
+position = Vector2(60, 90)
+
+[node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
+
+

--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -1,0 +1,25 @@
+extends Control
+
+# Preload the card scene for instantiation
+var CardScene := preload("res://scenes/card.tscn")
+
+@onready var card_container: HBoxContainer = $CardContainer
+@onready var beat_timer: Timer = $BeatTimer
+
+func _ready() -> void:
+    # Create a few example cards with different tones
+    for i in range(3):
+        var card: Button = CardScene.instantiate()
+        card.text = "Card %d" % (i + 1)
+        card.frequency = 220.0 * (i + 1)
+        card_container.add_child(card)
+    # Connect beat timer
+    beat_timer.timeout.connect(_on_beat)
+
+func _on_beat() -> void:
+    # Pulse animation on every simulated beat
+    for card in card_container.get_children():
+        var tween := create_tween()
+        tween.tween_property(card, "scale", Vector2(1.1, 1.1), 0.1).from(Vector2.ONE)
+        tween.tween_property(card, "scale", Vector2.ONE, 0.1)
+

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -1,0 +1,25 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource path="res://scenes/main.gd" type="Script" id=1]
+
+[node name="Main" type="Control"]
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource(1)
+
+[node name="CardContainer" type="HBoxContainer" parent="."]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+size_flags_horizontal = 4
+size_flags_vertical = 4
+alignment = 1
+
+[node name="BeatTimer" type="Timer" parent="."]
+wait_time = 1.0
+autostart = true
+
+


### PR DESCRIPTION
## Summary
- Add Godot 4.2 project featuring a basic card-based roguelike prototype
- Cards play procedural synth tones, spawn particles and pulse to timer beats
- Document setup and macOS run instructions

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bd79e2ff08323a3bca4e8e8a20f6e