### PR TITLE
Fix card scene resource ID conflict

### DIFF
--- a/scenes/card.tscn
+++ b/scenes/card.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource path="res://scenes/card.gd" type="Script" id=1]
 
-[sub_resource type="ParticleProcessMaterial" id=1]
+[sub_resource type="ParticleProcessMaterial" id=2]
 # Basic particle material; defaults create small burst
 
 [node name="Card" type="Button"]
@@ -15,7 +15,7 @@ emitting = false
 one_shot = true
 amount = 30
 lifetime = 0.5
-process_material = SubResource(1)
+process_material = SubResource(2)
 position = Vector2(60, 90)
 
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]


### PR DESCRIPTION
## Summary
- Avoid assigning card script to particle material by giving the particle material its own resource ID

## Testing
- `godot4 --headless scenes/main.tscn` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bdbc9aecc83238a957b81a62a29ef