### PR TITLE
Refactor particle material into external resource

### DIFF
--- a/scenes/card.tscn
+++ b/scenes/card.tscn
@@ -1,9 +1,7 @@
 [gd_scene load_steps=3 format=3]
 
 [ext_resource path="res://scenes/card.gd" type="Script" id=1]
-
-[sub_resource type="ParticleProcessMaterial" id=2]
-# Basic particle material; defaults create small burst
+[ext_resource path="res://scenes/card_particle_material.tres" type="ParticleProcessMaterial" id=2]
 
 [node name="Card" type="Button"]
 custom_minimum_size = Vector2(120, 180)
@@ -15,7 +13,7 @@ emitting = false
 one_shot = true
 amount = 30
 lifetime = 0.5
-process_material = SubResource(2)
+process_material = ExtResource(2)
 position = Vector2(60, 90)
 
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]

--- a/scenes/card_particle_material.tres
+++ b/scenes/card_particle_material.tres
@@ -1,0 +1,3 @@
+[gd_resource type="ParticleProcessMaterial" format=3]
+
+# Basic particle material; defaults create small burst


### PR DESCRIPTION
## Summary
- Extract particle effect's material to its own `.tres` file
- Reference external particle material in `Card` scene

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688be0064b248323af9435d78707fa05